### PR TITLE
Sign macOS objects depth-first (close #4932)

### DIFF
--- a/packages/app-builder-lib/electron-osx-sign/sign.js
+++ b/packages/app-builder-lib/electron-osx-sign/sign.js
@@ -119,6 +119,17 @@ async function verifySignApplicationAsync (opts) {
 function signApplicationAsync (opts) {
   return walkAsync(getAppContentsPath(opts))
     .then(async function (childPaths) {
+      /**
+       * Sort the child paths by how deep they are in the file tree.  Some arcane apple
+       * logic expects the deeper files to be signed first otherwise strange errors get
+       * thrown our way
+       */
+      childPaths = childPaths.sort((a, b) => {
+        const aDepth = a.split(path.sep).length
+        const bDepth = b.split(path.sep).length
+        return bDepth - aDepth
+      })
+
       function ignoreFilePath (opts, filePath) {
         if (opts.ignore) {
           return opts.ignore.some(function (ignore) {


### PR DESCRIPTION
This fix was directly lifted from https://github.com/electron/electron-osx-sign/pull/228 authored by @MarshallOfSound